### PR TITLE
Fix GitHub discovery docs: keyword search, not hash search

### DIFF
--- a/docs/discovery-methods.md
+++ b/docs/discovery-methods.md
@@ -53,19 +53,22 @@ def compute_swhid(directory_path):
 
 ### 1.2 GitHub Repository Search
 
-Uses the GitHub API to find repositories matching the SWHID.
+GitHub is used as a supplementary source to find candidate repositories by
+keyword. It does not perform hash or SWHID based matching. GitHub has no
+content hash search, so hash based lookup is handled entirely by Software
+Heritage (see 1.4 Software Heritage Archive).
 
 #### Search Strategy:
 
-1. **File-based Search**: Searches for unique file combinations
-2. **Content Matching**: Matches file contents against GitHub's index
-3. **Repository Metadata**: Extracts package information from found repositories
+1. **Keyword Search**: Queries the GitHub repository search API with the package name and related terms
+2. **Metadata Matching**: Matches against repository metadata such as name, description, and topics, not file contents
+3. **Package Metadata**: Reads packaging files from matched repositories to extract package information
 
 #### API Usage:
 
 ```python
-# Search by file content
-GET https://api.github.com/search/code?q=hash:SWHID
+# Search repositories by keyword (matches repository metadata, not file contents)
+GET https://api.github.com/search/repositories?q={keywords}
 
 # Get repository details
 GET https://api.github.com/repos/{owner}/{repo}
@@ -76,8 +79,10 @@ GET https://api.github.com/repos/{owner}/{repo}/contents/package.json
 
 #### Rate Limits:
 
-- Without token: 10 requests/hour
-- With token: 5000 requests/hour
+The GitHub search API is rate limited separately from the core REST API:
+
+- Without token: 10 requests/minute
+- With token: 30 requests/minute
 
 ### 1.3 SCANOSS Knowledge Base
 


### PR DESCRIPTION
Fixes #53.

## Problem

Section 1.2 "GitHub Repository Search" in `docs/discovery-methods.md` was copy-pasted from the Software Heritage hash-lookup content and never updated for GitHub. It claimed src2purl finds repositories by searching GitHub's index with a SWHID:

```
GET https://api.github.com/search/code?q=hash:SWHID
```

That call does not exist. GitHub has no content hash or SWHID search, which is why the reporter could not find it documented or get it to work.

## What the code actually does

The GitHub provider (`GitHubSearchProvider`) performs a repository keyword search via `search/repositories`, matching repository metadata such as name and description. It never touches file contents, and `search/code` is not used anywhere. Hash-based lookup is a Software Heritage feature (SWHID), handled by the Software Heritage client.

## Fix

- Rewrote section 1.2 to describe the GitHub provider as a keyword search against repository metadata, not a hash or content search.
- Removed the fictional `search/code?q=hash:SWHID` example and pointed hash-based lookup to section 1.4 (Software Heritage Archive).
- Corrected the search API rate limits to their per-minute values (10/min unauthenticated, 30/min authenticated).

## Possible follow-ups (not in this PR)

- `hash_search.py` computes a sha256 that is never searched, and routes hash queries through the repository keyword search where they cannot match. If hash-based file lookup on top of GitHub is wanted, it would need to go through Software Heritage (which supports sha1_git and sha256 content lookups), not GitHub.
