### PR TITLE
Keep third-party licenses in oslili aggregation without attributing them to the package

### DIFF
--- a/src2id/core/package_identifier.py
+++ b/src2id/core/package_identifier.py
@@ -82,8 +82,12 @@ class PackageIdentifier:
                         
                         if integration.available:
                             license_info = integration.detect_licenses(path)
-                            if license_info["licenses"]:
-                                match.license = ", ".join(license_info["licenses"][:3])
+                            # Only the project's own licenses identify this package;
+                            # licenses from bundled third-party notice files belong
+                            # to its dependencies
+                            own_licenses = license_info.get("own_licenses") or []
+                            if own_licenses:
+                                match.license = ", ".join(own_licenses[:3])
                     except ImportError:
                         pass
                 

--- a/src2id/integrations/oslili.py
+++ b/src2id/integrations/oslili.py
@@ -202,22 +202,24 @@ class OsliliIntegration:
         # Detect licenses
         license_info = self.detect_licenses(path)
         
+        # Only the project's own licenses are eligible to become this package's
+        # license: one found in a bundled third-party notice file belongs to a
+        # dependency, so attributing it here would be wrong. Bundled notices must
+        # therefore neither raise nor lower the bar for the own license, which is
+        # why the decision below uses own_confidence rather than the aggregate.
+        own_licenses = self._deduplicate_licenses(license_info.get("own_licenses") or [])
+        own_confidence = license_info.get("own_confidence") or 0.0
+
         # Update match if we found licenses with good confidence
-        if license_info["licenses"] and license_info["confidence"] > 0.7:
+        if license_info["licenses"] and (
+            license_info["confidence"] > 0.7 or own_confidence > 0.7
+        ):
             # Remove duplicates while preserving order
             unique_licenses = self._deduplicate_licenses(license_info["licenses"])
             
-            # Use the most confident license as primary. Only the project's own
-            # licenses are eligible: a license found in a bundled third-party notice
-            # file belongs to a dependency, so attributing it to this package would
-            # be wrong. When nothing but bundled notices was found we leave
-            # match.license alone rather than guess.
-            own_licenses = self._deduplicate_licenses(license_info.get("own_licenses") or [])
-            own_confidence = license_info.get("own_confidence") or 0.0
-
             # Update match license if not already set or if ours is more confident.
-            # Gated on own_confidence so bundled notices cannot raise the bar-clearing
-            # score for a license they had no part in detecting.
+            # When nothing but bundled notices was found there is no own license, so
+            # match.license is left alone rather than guessed at.
             if own_licenses and own_confidence > 0.7 and (
                 not match.license or own_confidence > 0.85
             ):

--- a/src2id/integrations/oslili.py
+++ b/src2id/integrations/oslili.py
@@ -59,6 +59,8 @@ class OsliliIntegration:
         Returns:
             Dictionary with license information:
             - licenses: List of detected license identifiers
+            - own_licenses: Identifiers eligible to be the project's own license
+            - third_party_licenses: Identifiers from bundled third-party notice files
             - confidence: Confidence score (0-1)
             - files: Dict mapping files to their licenses
             - summary: Human-readable summary
@@ -66,6 +68,8 @@ class OsliliIntegration:
         if not self.available or not self.detector:
             return {
                 "licenses": [],
+                "own_licenses": [],
+                "third_party_licenses": [],
                 "confidence": 0.0,
                 "files": {},
                 "summary": "oslili not available",
@@ -93,7 +97,8 @@ class OsliliIntegration:
 
                 # Prioritize declared licenses, then detected, then referenced,
                 # with bundled third-party licenses last
-                all_licenses = declared + detected + referenced + third_party
+                own = declared + detected + referenced
+                all_licenses = own + third_party
 
                 for license_info in all_licenses:
                     licenses.append(license_info.spdx_id)
@@ -131,6 +136,13 @@ class OsliliIntegration:
                 
                 return {
                     "licenses": licenses,
+                    # Split view of the same licenses: "own" are candidates for the
+                    # project's license, "third_party" come from bundled notice files
+                    # and must not be attributed to the project itself.
+                    "own_licenses": self._deduplicate_licenses([lic.spdx_id for lic in own]),
+                    "third_party_licenses": self._deduplicate_licenses(
+                        [lic.spdx_id for lic in third_party]
+                    ),
                     "confidence": avg_confidence,
                     "files": files,
                     "summary": summary,
@@ -139,6 +151,8 @@ class OsliliIntegration:
             else:
                 return {
                     "licenses": [],
+                    "own_licenses": [],
+                    "third_party_licenses": [],
                     "confidence": 0.0,
                     "files": {},
                     "summary": "No licenses detected",
@@ -148,6 +162,8 @@ class OsliliIntegration:
         except Exception as e:
             return {
                 "licenses": [],
+                "own_licenses": [],
+                "third_party_licenses": [],
                 "confidence": 0.0,
                 "files": {},
                 "summary": f"Error during detection: {e}",
@@ -180,12 +196,16 @@ class OsliliIntegration:
             # Remove duplicates while preserving order
             unique_licenses = self._deduplicate_licenses(license_info["licenses"])
             
-            # Use the most confident license as primary
-            primary_license = unique_licenses[0]
+            # Use the most confident license as primary. Only the project's own
+            # licenses are eligible: a license found in a bundled third-party notice
+            # file belongs to a dependency, so attributing it to this package would
+            # be wrong. When nothing but bundled notices was found we leave
+            # match.license alone rather than guess.
+            own_licenses = self._deduplicate_licenses(license_info.get("own_licenses") or [])
             
             # Update match license if not already set or if ours is more confident
-            if not match.license or license_info["confidence"] > 0.85:
-                match.license = primary_license
+            if own_licenses and (not match.license or license_info["confidence"] > 0.85):
+                match.license = own_licenses[0]
             
             # Add metadata about additional licenses and copyrights
             if not hasattr(match, "metadata"):
@@ -193,6 +213,11 @@ class OsliliIntegration:
             
             if len(unique_licenses) > 1:
                 match.metadata["additional_licenses"] = unique_licenses[1:]
+
+            # Surface bundled third-party licenses separately so callers can report
+            # them without mistaking them for the package's own license
+            if license_info.get("third_party_licenses"):
+                match.metadata["third_party_licenses"] = license_info["third_party_licenses"]
             
             match.metadata["license_confidence"] = license_info["confidence"]
             

--- a/src2id/integrations/oslili.py
+++ b/src2id/integrations/oslili.py
@@ -83,13 +83,18 @@ class OsliliIntegration:
                 files = {}
                 
                 # Group licenses by category for better understanding
-                declared = [l for l in result.licenses if l.category == "declared"]
-                detected = [l for l in result.licenses if l.category == "detected"]
-                referenced = [l for l in result.licenses if l.category == "referenced"]
-                
-                # Prioritize declared licenses, then detected, then referenced
-                all_licenses = declared + detected + referenced
-                
+                declared = [lic for lic in result.licenses if lic.category == "declared"]
+                detected = [lic for lic in result.licenses if lic.category == "detected"]
+                referenced = [lic for lic in result.licenses if lic.category == "referenced"]
+                # Licenses of bundled dependencies (THIRD_PARTY_NOTICES.txt and
+                # friends), not the project's own license. Kept, but ranked last so
+                # they never win the primary-license selection.
+                third_party = [lic for lic in result.licenses if lic.category == "third-party"]
+
+                # Prioritize declared licenses, then detected, then referenced,
+                # with bundled third-party licenses last
+                all_licenses = declared + detected + referenced + third_party
+
                 for license_info in all_licenses:
                     licenses.append(license_info.spdx_id)
                     confidence_scores.append(license_info.confidence)

--- a/src2id/integrations/oslili.py
+++ b/src2id/integrations/oslili.py
@@ -61,7 +61,8 @@ class OsliliIntegration:
             - licenses: List of detected license identifiers
             - own_licenses: Identifiers eligible to be the project's own license
             - third_party_licenses: Identifiers from bundled third-party notice files
-            - confidence: Confidence score (0-1)
+            - confidence: Confidence score (0-1) across all detections
+            - own_confidence: Confidence score (0-1) across own licenses only
             - files: Dict mapping files to their licenses
             - summary: Human-readable summary
         """
@@ -71,6 +72,7 @@ class OsliliIntegration:
                 "own_licenses": [],
                 "third_party_licenses": [],
                 "confidence": 0.0,
+                "own_confidence": 0.0,
                 "files": {},
                 "summary": "oslili not available",
                 "error": "oslili integration not available"
@@ -117,6 +119,12 @@ class OsliliIntegration:
                 
                 # Calculate average confidence
                 avg_confidence = sum(confidence_scores) / len(confidence_scores) if confidence_scores else 0.8
+
+                # Confidence in the project's own licenses, kept separate so a pile of
+                # high-confidence bundled notice files cannot inflate the score used to
+                # decide the package's own license
+                own_scores = [lic.confidence for lic in own]
+                own_confidence = sum(own_scores) / len(own_scores) if own_scores else 0.0
                 
                 # Generate summary
                 if licenses:
@@ -144,6 +152,7 @@ class OsliliIntegration:
                         [lic.spdx_id for lic in third_party]
                     ),
                     "confidence": avg_confidence,
+                    "own_confidence": own_confidence,
                     "files": files,
                     "summary": summary,
                     "copyrights": [c.to_dict() for c in result.copyrights] if result.copyrights else []
@@ -154,6 +163,7 @@ class OsliliIntegration:
                     "own_licenses": [],
                     "third_party_licenses": [],
                     "confidence": 0.0,
+                    "own_confidence": 0.0,
                     "files": {},
                     "summary": "No licenses detected",
                     "copyrights": []
@@ -165,6 +175,7 @@ class OsliliIntegration:
                 "own_licenses": [],
                 "third_party_licenses": [],
                 "confidence": 0.0,
+                "own_confidence": 0.0,
                 "files": {},
                 "summary": f"Error during detection: {e}",
                 "error": str(e)
@@ -202,9 +213,14 @@ class OsliliIntegration:
             # be wrong. When nothing but bundled notices was found we leave
             # match.license alone rather than guess.
             own_licenses = self._deduplicate_licenses(license_info.get("own_licenses") or [])
-            
-            # Update match license if not already set or if ours is more confident
-            if own_licenses and (not match.license or license_info["confidence"] > 0.85):
+            own_confidence = license_info.get("own_confidence") or 0.0
+
+            # Update match license if not already set or if ours is more confident.
+            # Gated on own_confidence so bundled notices cannot raise the bar-clearing
+            # score for a license they had no part in detecting.
+            if own_licenses and own_confidence > 0.7 and (
+                not match.license or own_confidence > 0.85
+            ):
                 match.license = own_licenses[0]
             
             # Add metadata about additional licenses and copyrights

--- a/tests/unit/test_oslili_integration.py
+++ b/tests/unit/test_oslili_integration.py
@@ -1,0 +1,162 @@
+"""Unit tests for the oslili license detection integration."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src2id.integrations.oslili import OsliliIntegration
+
+
+def make_license(spdx_id, category, confidence=0.95, source_file=None):
+    """Build a stand-in for an osslili DetectedLicense."""
+    return SimpleNamespace(
+        spdx_id=spdx_id,
+        category=category,
+        confidence=confidence,
+        source_file=source_file or f"{spdx_id}.txt",
+        detection_method="full_text",
+    )
+
+
+class FakeDetector:
+    """Stand-in for osslili's LicenseCopyrightDetector."""
+
+    def __init__(self, licenses, copyrights=None):
+        self.licenses = licenses
+        self.copyrights = copyrights or []
+
+    def process_local_path(self, path):
+        return SimpleNamespace(licenses=self.licenses, copyrights=self.copyrights)
+
+
+@pytest.fixture
+def integration():
+    """Integration wired to a fake detector, independent of osslili being installed."""
+
+    def _build(licenses, copyrights=None):
+        instance = OsliliIntegration.__new__(OsliliIntegration)
+        instance.available = True
+        instance.detector = FakeDetector(licenses, copyrights)
+        return instance
+
+    return _build
+
+
+class TestThirdPartyCategory:
+    """osslili 1.7.0 categorizes bundled notice files as `third-party`."""
+
+    def test_third_party_licenses_are_retained(self, integration):
+        """A third-party license must not be dropped from the aggregation."""
+        detector = integration(
+            [
+                make_license("Apache-2.0", "declared", source_file="LICENSE"),
+                make_license("MIT", "third-party", source_file="THIRD_PARTY_NOTICES.txt"),
+            ]
+        )
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        assert result["licenses"] == ["Apache-2.0", "MIT"]
+
+    def test_third_party_never_outranks_project_license(self, integration):
+        """Third-party licenses sort last, so primary selection is unaffected."""
+        detector = integration(
+            [
+                make_license("GPL-3.0-only", "third-party", source_file="3rdpartylicenses.txt"),
+                make_license("BSD-3-Clause", "referenced", source_file="README.md"),
+                make_license("Apache-2.0", "detected", source_file="src/main.py"),
+                make_license("MIT", "declared", source_file="LICENSE"),
+            ]
+        )
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        # declared -> detected -> referenced -> third-party
+        assert result["licenses"] == [
+            "MIT",
+            "Apache-2.0",
+            "BSD-3-Clause",
+            "GPL-3.0-only",
+        ]
+        assert result["licenses"][0] == "MIT"
+
+    def test_third_party_only_still_reports_the_license(self, integration):
+        """When only bundled notices exist, the license is still surfaced."""
+        detector = integration(
+            [
+                make_license("MIT", "third-party", source_file="THIRD_PARTY_NOTICES.txt"),
+                make_license("ISC", "third-party", source_file="THIRD_PARTY_NOTICES.txt"),
+            ]
+        )
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        assert result["licenses"] == ["MIT", "ISC"]
+        assert result["files"]["THIRD_PARTY_NOTICES.txt"][0]["category"] == "third-party"
+
+    def test_third_party_license_is_mapped_to_its_source_file(self, integration):
+        """The file mapping records the third-party category for downstream use."""
+        detector = integration(
+            [
+                make_license("Apache-2.0", "declared", source_file="LICENSE"),
+                make_license("MIT", "third-party", source_file="THIRD_PARTY_NOTICES.txt"),
+            ]
+        )
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        assert set(result["files"]) == {"LICENSE", "THIRD_PARTY_NOTICES.txt"}
+        notice_entry = result["files"]["THIRD_PARTY_NOTICES.txt"][0]
+        assert notice_entry["spdx_id"] == "MIT"
+        assert notice_entry["category"] == "third-party"
+
+    def test_legacy_categories_are_unaffected(self, integration):
+        """Pre-1.7.0 osslili output (no third-party category) behaves as before."""
+        detector = integration(
+            [
+                make_license("BSD-3-Clause", "referenced", source_file="README.md"),
+                make_license("MIT", "declared", source_file="LICENSE"),
+                make_license("Apache-2.0", "detected", source_file="src/main.py"),
+            ]
+        )
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        assert result["licenses"] == ["MIT", "Apache-2.0", "BSD-3-Clause"]
+
+    def test_unknown_future_category_does_not_crash(self, integration):
+        """An unrecognized category is skipped without raising."""
+        detector = integration(
+            [
+                make_license("MIT", "declared", source_file="LICENSE"),
+                make_license("Apache-2.0", "some-future-category"),
+            ]
+        )
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        assert result["licenses"] == ["MIT"]
+
+
+class TestEnhancePackageMatch:
+    """Primary-license selection must prefer the project's own license."""
+
+    def test_primary_license_prefers_declared_over_third_party(self, integration):
+        detector = integration(
+            [
+                make_license(
+                    "GPL-3.0-only",
+                    "third-party",
+                    confidence=0.99,
+                    source_file="THIRD_PARTY_NOTICES.txt",
+                ),
+                make_license("Apache-2.0", "declared", confidence=0.99, source_file="LICENSE"),
+            ]
+        )
+        match = SimpleNamespace(license=None, metadata={})
+
+        enhanced = detector.enhance_package_match(match, Path("/some/project"))
+
+        assert enhanced.license == "Apache-2.0"
+        assert enhanced.metadata["additional_licenses"] == ["GPL-3.0-only"]

--- a/tests/unit/test_oslili_integration.py
+++ b/tests/unit/test_oslili_integration.py
@@ -1,7 +1,9 @@
 """Unit tests for the oslili license detection integration."""
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -256,3 +258,122 @@ class TestDetectLicensesSplitView:
 
         assert result["own_licenses"] == []
         assert result["third_party_licenses"] == []
+        assert result["own_confidence"] == 0.0
+
+
+class TestOwnConfidence:
+    """Third-party notices must not inflate the score used to pick the own license."""
+
+    def test_own_confidence_excludes_third_party(self, integration):
+        detector = integration(
+            [
+                make_license("Apache-2.0", "detected", confidence=0.5, source_file="a.py"),
+                make_license(
+                    "MIT",
+                    "third-party",
+                    confidence=1.0,
+                    source_file="THIRD_PARTY_NOTICES.txt",
+                ),
+            ]
+        )
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        # Overall confidence still averages everything that was detected
+        assert result["confidence"] == pytest.approx(0.75)
+        # ...but the own-license score reflects only the own detection
+        assert result["own_confidence"] == pytest.approx(0.5)
+
+    def test_high_confidence_notices_do_not_overwrite_known_license(self, integration):
+        """A weak own detection must not clobber a known license on inflated score.
+
+        Enough high-confidence bundled notices push the aggregate above the 0.85
+        overwrite threshold while the own detection alone stays well below it.
+        """
+        detector = integration(
+            [
+                make_license("BSD-3-Clause", "detected", confidence=0.6, source_file="a.py"),
+                make_license("MIT", "third-party", confidence=1.0, source_file="notices/a.txt"),
+                make_license("ISC", "third-party", confidence=1.0, source_file="notices/b.txt"),
+            ]
+        )
+        match = SimpleNamespace(license="Apache-2.0", metadata={})
+
+        result = detector.detect_licenses(Path("/some/project"))
+        # Aggregate clears the 0.85 overwrite bar purely because of the notices
+        assert result["confidence"] > 0.85
+        assert result["own_confidence"] == pytest.approx(0.6)
+
+        enhanced = detector.enhance_package_match(match, Path("/some/project"))
+
+        # ...so gating on own confidence is what keeps the known license intact
+        assert enhanced.license == "Apache-2.0"
+        assert enhanced.metadata["third_party_licenses"] == ["MIT", "ISC"]
+
+    def test_confident_own_license_still_sets_the_license(self, integration):
+        """The normal path is unchanged: a confident own license is still applied."""
+        detector = integration(
+            [
+                make_license("BSD-3-Clause", "declared", confidence=0.99, source_file="LICENSE"),
+                make_license(
+                    "MIT",
+                    "third-party",
+                    confidence=0.99,
+                    source_file="THIRD_PARTY_NOTICES.txt",
+                ),
+            ]
+        )
+        match = SimpleNamespace(license="Apache-2.0", metadata={})
+
+        enhanced = detector.enhance_package_match(match, Path("/some/project"))
+
+        assert enhanced.license == "BSD-3-Clause"
+
+
+class TestPackageIdentifierLicenseAttribution:
+    """The other direct detect_licenses() caller must not attribute bundled licenses.
+
+    Driven through asyncio.run rather than pytest.mark.asyncio: CI installs only
+    pytest and pytest-cov, so the suite must not depend on pytest-asyncio.
+    """
+
+    def _identify(self, licenses):
+        """Run PackageIdentifier.identify_packages with oslili returning `licenses`."""
+        from src2id.core.package_identifier import PackageIdentifier
+
+        integration = OsliliIntegration.__new__(OsliliIntegration)
+        integration.available = True
+        integration.detector = FakeDetector(licenses)
+
+        async def fake_identify_source(**kwargs):
+            return {
+                "identified": True,
+                "confidence": 0.9,
+                "final_origin": "https://example.com/pkg",
+                "candidates": [],
+            }
+
+        with patch("src2id.core.package_identifier.identify_source", fake_identify_source):
+            with patch("src2id.integrations.oslili.OsliliIntegration", return_value=integration):
+                matches = asyncio.run(PackageIdentifier().identify_packages(Path("/some/project")))
+
+        assert len(matches) == 1
+        return matches[0]
+
+    def test_third_party_only_leaves_license_unset(self):
+        """A bundled dependency license must not identify the package."""
+        match = self._identify(
+            [make_license("MIT", "third-party", source_file="THIRD_PARTY_NOTICES.txt")]
+        )
+
+        assert match.license == ""
+
+    def test_own_license_is_used(self):
+        match = self._identify(
+            [
+                make_license("Apache-2.0", "declared", source_file="LICENSE"),
+                make_license("MIT", "third-party", source_file="THIRD_PARTY_NOTICES.txt"),
+            ]
+        )
+
+        assert match.license == "Apache-2.0"

--- a/tests/unit/test_oslili_integration.py
+++ b/tests/unit/test_oslili_integration.py
@@ -310,6 +310,32 @@ class TestOwnConfidence:
         assert enhanced.license == "Apache-2.0"
         assert enhanced.metadata["third_party_licenses"] == ["MIT", "ISC"]
 
+    def test_low_confidence_notices_do_not_suppress_a_confident_own_license(self, integration):
+        """Many weak bundled notices must not drag the aggregate below the gate.
+
+        The mirror image of inflation: a pile of low-confidence notice files pulls
+        the aggregate under 0.7, which must not stop a confident own license from
+        being applied.
+        """
+        detector = integration(
+            [make_license("Apache-2.0", "declared", confidence=0.95, source_file="LICENSE")]
+            + [
+                make_license("MIT", "third-party", confidence=0.1, source_file=f"NOTICE-{i}")
+                for i in range(4)
+            ]
+        )
+        match = SimpleNamespace(license=None, metadata={})
+
+        result = detector.detect_licenses(Path("/some/project"))
+        # The aggregate is dragged well below the 0.7 gate...
+        assert result["confidence"] < 0.7
+        # ...while the own license was detected with high confidence
+        assert result["own_confidence"] == pytest.approx(0.95)
+
+        enhanced = detector.enhance_package_match(match, Path("/some/project"))
+
+        assert enhanced.license == "Apache-2.0"
+
     def test_confident_own_license_still_sets_the_license(self, integration):
         """The normal path is unchanged: a confident own license is still applied."""
         detector = integration(
@@ -353,9 +379,14 @@ class TestPackageIdentifierLicenseAttribution:
                 "candidates": [],
             }
 
-        with patch("src2id.core.package_identifier.identify_source", fake_identify_source):
-            with patch("src2id.integrations.oslili.OsliliIntegration", return_value=integration):
-                matches = asyncio.run(PackageIdentifier().identify_packages(Path("/some/project")))
+        # Bound separately so a single with-statement stays inside the 3.9 syntax
+        # this package supports (parenthesized context managers are 3.10+)
+        patch_source = patch("src2id.core.package_identifier.identify_source", fake_identify_source)
+        patch_oslili = patch(
+            "src2id.integrations.oslili.OsliliIntegration", return_value=integration
+        )
+        with patch_source, patch_oslili:
+            matches = asyncio.run(PackageIdentifier().identify_packages(Path("/some/project")))
 
         assert len(matches) == 1
         return matches[0]

--- a/tests/unit/test_oslili_integration.py
+++ b/tests/unit/test_oslili_integration.py
@@ -160,3 +160,99 @@ class TestEnhancePackageMatch:
 
         assert enhanced.license == "Apache-2.0"
         assert enhanced.metadata["additional_licenses"] == ["GPL-3.0-only"]
+        assert enhanced.metadata["third_party_licenses"] == ["GPL-3.0-only"]
+
+    def test_third_party_only_does_not_become_the_package_license(self, integration):
+        """A bundled dependency license must not be attributed to the package."""
+        detector = integration(
+            [
+                make_license(
+                    "GPL-3.0-only",
+                    "third-party",
+                    confidence=0.99,
+                    source_file="THIRD_PARTY_NOTICES.txt",
+                ),
+            ]
+        )
+        match = SimpleNamespace(license=None, metadata={})
+
+        enhanced = detector.enhance_package_match(match, Path("/some/project"))
+
+        assert enhanced.license is None
+        # ...but it is still reported, just not as the package's own license
+        assert enhanced.metadata["third_party_licenses"] == ["GPL-3.0-only"]
+
+    def test_third_party_only_does_not_overwrite_an_existing_license(self, integration):
+        """A high-confidence bundled notice must not clobber a known license."""
+        detector = integration(
+            [
+                make_license(
+                    "GPL-3.0-only",
+                    "third-party",
+                    confidence=0.99,
+                    source_file="THIRD_PARTY_NOTICES.txt",
+                ),
+            ]
+        )
+        match = SimpleNamespace(license="Apache-2.0", metadata={})
+
+        enhanced = detector.enhance_package_match(match, Path("/some/project"))
+
+        assert enhanced.license == "Apache-2.0"
+        assert enhanced.metadata["third_party_licenses"] == ["GPL-3.0-only"]
+
+    def test_own_license_still_wins_when_only_referenced(self, integration):
+        """A referenced license is still the project's own and remains eligible."""
+        detector = integration(
+            [
+                make_license("MIT", "third-party", source_file="3rdpartylicenses.txt"),
+                make_license("BSD-3-Clause", "referenced", source_file="README.md"),
+            ]
+        )
+        match = SimpleNamespace(license=None, metadata={})
+
+        enhanced = detector.enhance_package_match(match, Path("/some/project"))
+
+        assert enhanced.license == "BSD-3-Clause"
+
+
+class TestDetectLicensesSplitView:
+    """detect_licenses reports own and third-party licenses separately."""
+
+    def test_split_buckets(self, integration):
+        detector = integration(
+            [
+                make_license("Apache-2.0", "declared", source_file="LICENSE"),
+                make_license("BSD-3-Clause", "detected", source_file="src/main.py"),
+                make_license("MIT", "third-party", source_file="THIRD_PARTY_NOTICES.txt"),
+            ]
+        )
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        assert result["own_licenses"] == ["Apache-2.0", "BSD-3-Clause"]
+        assert result["third_party_licenses"] == ["MIT"]
+        assert result["licenses"] == ["Apache-2.0", "BSD-3-Clause", "MIT"]
+
+    def test_same_license_can_be_both_own_and_third_party(self, integration):
+        """Overlap is reported in both buckets, not resolved by set difference."""
+        detector = integration(
+            [
+                make_license("MIT", "declared", source_file="LICENSE"),
+                make_license("MIT", "third-party", source_file="THIRD_PARTY_NOTICES.txt"),
+            ]
+        )
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        assert result["own_licenses"] == ["MIT"]
+        assert result["third_party_licenses"] == ["MIT"]
+
+    def test_keys_present_when_nothing_detected(self, integration):
+        """The contract holds on the empty path too."""
+        detector = integration([])
+
+        result = detector.detect_licenses(Path("/some/project"))
+
+        assert result["own_licenses"] == []
+        assert result["third_party_licenses"] == []


### PR DESCRIPTION
Closes #55.

## Problem

osslili 1.7.0 (SemClone/osslili#87) added a `THIRD_PARTY` license category. Licenses found in bundled third-party notice files (`THIRD_PARTY_NOTICES.txt`, `3rdpartylicenses.txt`, ...) are now categorized `third-party` instead of `declared`.

`src2id/integrations/oslili.py` hard-coded the three legacy categories when aggregating, so those licenses were silently dropped from the license list and from primary-license selection.

## Changes

The first commit is the fix from the issue: capture a `third_party` bucket and append it last, so third-party licenses are recorded but rank behind declared/detected/referenced.

Recording them again, however, made them reachable by the code that decides a package's own license, which could not happen while they were being dropped. The remaining commits close the three paths where a bundled dependency's license could have been attributed to the package itself:

- `enhance_package_match()` assigned `all_licenses[0]` to `match.license`, so a scan that found nothing but notice files named a dependency's license as the package's.
- `package_identifier.py` joined the first three entries of `licenses` into `match.license`, with the same effect.
- The primary-license confidence gate compared the aggregate confidence, which now averages own and third-party detections together. That cuts both ways: enough high-confidence notice files could push the average past the 0.85 overwrite threshold and replace an already-known license on a weak own detection, while enough low-confidence ones could drag it under 0.7 and suppress a confident own license entirely.

`detect_licenses()` therefore also reports a split view, `own_licenses` / `third_party_licenses` / `own_confidence`, mirroring the `third_party_licenses` field osslili added to its KissBOM output. Primary-license decisions use the own values; third-party licenses are still reported, under `metadata["third_party_licenses"]`.

The new keys are additive and present on every return path, so existing callers reading `licenses` or `confidence` are unaffected. When a scan finds no third-party licenses, `own_confidence` equals `confidence` and behaviour is identical to before.

The CLI's local-source report still lists every detected license. It describes what was found rather than attributing a license to the package, which is the distinction driving the changes above.

## Backward compatibility

Nothing carries the `third-party` category before osslili 1.7.0, so this no-ops against older osslili and activates once 1.7.0+ is installed. There is no release-ordering constraint.

## Tests

New `tests/unit/test_oslili_integration.py` covers retention and ordering of third-party licenses, the split view including the case where the same SPDX id is both own and third-party, primary-license selection, both confidence-gate directions, and pre-1.7.0 output being unaffected. The `PackageIdentifier` case drives the real coroutine via `asyncio.run` rather than `pytest.mark.asyncio`, since CI installs only pytest and pytest-cov.

Full suite: 115 passed. Six of the new tests fail against the unfixed code, confirming they pin the regressions.

Refs SemClone/osslili#87, SemClone/osslili#78.